### PR TITLE
fix: no need to clean cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ run/
 dist/
 .cache
 test/fixtures/app*/typings
+.history

--- a/src/register.ts
+++ b/src/register.ts
@@ -49,15 +49,5 @@ function register(watch: boolean) {
   // cache pid
   if (watch) {
     fs.writeFileSync(cacheFile, process.pid);
-
-    const clean = () => fs.existsSync(cacheFile) && fs.unlinkSync(cacheFile);
-
-    // delete cache file on exit.
-    process.once('beforeExit', clean);
-    process.once('uncaughtException', clean);
-    process.once('SIGINT', () => {
-      clean();
-      process.exit(0);
-    });
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Register will check wether the pid is still alive on startup, so it's no need to clean cache file after process exits( it may cause https://github.com/whxaxes/egg-ts-helper/issues/35 ) 

- close https://github.com/whxaxes/egg-ts-helper/issues/35