### PR TITLE
egg 插件可以配置 path

### DIFF
--- a/src/generators/plugin.ts
+++ b/src/generators/plugin.ts
@@ -26,7 +26,7 @@ export default function(config: TsGenConfig, baseConfig: TsHelperConfig) {
       if (pluginInfo.package && pluginInfo.from) {
         appPluginNameList.push(name);
         if (pluginInfo.enable) {
-          importContent.push(`import '${pluginInfo.package}';`);
+          importContent.push(`import '${pluginInfo.package || pluginInfo.path}';`);
         }
       }
     });


### PR DESCRIPTION
egg 插件是可以设置 path 的，主要是本地的插件，没有 package 字段 https://eggjs.org/zh-cn/basics/plugin.html#%E5%8F%82%E6%95%B0%E4%BB%8B%E7%BB%8D

出现问题的例子如下

```js
export default {
  test: {
    enable: true,
    path: path.resolve(__dirname, '../plugin/egg-test'),
  },
}
```

会导致使用 midway 2.x 之后生成的 typings 出现问题

```js
import undefined
```