### PR TITLE
fix: use execFile for getEggInfo

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import ts from 'typescript';
 import yn from 'yn';
 import { eggInfoPath, tmpDir } from './config';
-import { execSync, exec, ExecOptions } from 'child_process';
+import { execFileSync, execFile, ExecFileOptions } from 'child_process';
 import JSON5 from 'json5';
 
 export const JS_CONFIG = {
@@ -104,8 +104,9 @@ export function getEggInfo<T extends 'async' | 'sync' = 'sync'>(option: GetEggIn
   }
 
   // prepare options
-  const cmd = `node ${path.resolve(__dirname, './scripts/eggInfo')}`;
-  const opt: ExecOptions = {
+  const cmd = 'node';
+  const args = [ path.resolve(__dirname, './scripts/eggInfo') ];
+  const opt: ExecFileOptions = {
     cwd,
     env: {
       ...process.env,
@@ -121,7 +122,7 @@ export function getEggInfo<T extends 'async' | 'sync' = 'sync'>(option: GetEggIn
   if (option.async) {
     // cache promise
     caches.runningPromise = new Promise((resolve, reject) => {
-      exec(cmd, opt, err => {
+      execFile(cmd, args, opt, err => {
         caches.runningPromise = null;
         if (err) reject(err);
         resolve(end(parseJson(fs.readFileSync(eggInfoPath, 'utf-8'))));
@@ -132,7 +133,7 @@ export function getEggInfo<T extends 'async' | 'sync' = 'sync'>(option: GetEggIn
   }
 
   try {
-    execSync(cmd, opt);
+    execFileSync(cmd, args, opt);
     return end(parseJson(fs.readFileSync(eggInfoPath, 'utf-8')));
   } catch (e) {
     return end({});


### PR DESCRIPTION
ISSUES CLOSED: #85

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
无

##### Description of change
<!-- Provide a description of the change below this comment. -->
使用`execFile`替换`exec`，路径作为参数传入，不再使用字符串拼接的方式
